### PR TITLE
Minor improvements

### DIFF
--- a/README
+++ b/README
@@ -67,7 +67,7 @@ software, and you are welcome to redistribute it under certain conditions;
 for details, see COPYING file.
 
 Option "--photosDir" is required
-usage: FlickrDownload  [--addExtensionToUnknownFiles VAL] [--authDir VAL] [--authUsername VAL] [--debug] [--downloadExifData] [--limitToSet VAL ...] [--partial] --photosDir VAL [--photosUsername VAL]
+usage: FlickrDownload  [--addExtensionToUnknownFiles VAL] [--authDir VAL] [--authUsername VAL] [--debug] [--downloadExifData] [--onlyData] [--limitToSet VAL ...] [--partial] --photosDir VAL [--photosUsername VAL]
 
 I typically run it like this:
 

--- a/dev/src/java/org/gftp/FlickrDownload/Configuration.java
+++ b/dev/src/java/org/gftp/FlickrDownload/Configuration.java
@@ -13,6 +13,7 @@ package org.gftp.FlickrDownload;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -35,6 +36,7 @@ public class Configuration {
 	public boolean partialDownloads = false;
 	public boolean onlyData = false;
 	public String addExtensionToUnknownFiles;
+	public List<String> limitDownloadsToSets;
 	public Auth auth;
 	
 	public Configuration(Flickr flickr, File photosBaseDirectory, File authDirectory, String userName) throws IOException, FlickrException, SAXException, ParserConfigurationException {

--- a/dev/src/java/org/gftp/FlickrDownload/FlickrDownload.java
+++ b/dev/src/java/org/gftp/FlickrDownload/FlickrDownload.java
@@ -211,6 +211,7 @@ public class FlickrDownload {
 		configuration.downloadExifData = values.downloadExifData;
 		configuration.partialDownloads = values.partial;
 		configuration.addExtensionToUnknownFiles = values.addExtensionToUnknownFiles;
+        configuration.limitDownloadsToSets = values.limitDownloadsToSets;
 
 		if (values.debug) {
 			Flickr.debugRequest = true;

--- a/dev/src/java/org/gftp/FlickrDownload/FlickrDownload.java
+++ b/dev/src/java/org/gftp/FlickrDownload/FlickrDownload.java
@@ -222,7 +222,7 @@ public class FlickrDownload {
 		Sets sets = new Sets(configuration, flickr);
 
 		// The photos must be downloaded before the toplevel XML files are created
-		sets.downloadAllPhotos(values.limitDownloadsToSets);
+		sets.downloadAllPhotos();
 
 		createdToplevelFiles.addAll(createTopLevelFiles(configuration, collections, sets));
 

--- a/dev/src/java/org/gftp/FlickrDownload/FlickrDownload.java
+++ b/dev/src/java/org/gftp/FlickrDownload/FlickrDownload.java
@@ -227,15 +227,4 @@ public class FlickrDownload {
 
 		IOUtils.findFilesThatDoNotBelong(configuration.photosBaseDirectory, createdToplevelFiles, configuration.addExtensionToUnknownFiles);
 	}
-
-
-	protected static String join(Iterable parts, String join) {
-		String ret = "";
-		for (Object part : parts) {
-			if (!ret.equals(""))
-				ret += join;
-			ret += part;
-		}
-		return ret;
-	}
 }

--- a/dev/src/java/org/gftp/FlickrDownload/Sets.java
+++ b/dev/src/java/org/gftp/FlickrDownload/Sets.java
@@ -92,9 +92,9 @@ public class Sets {
     	}		
 	}
 
-	public void downloadAllPhotos(Collection<String> limitDownloadsToSets) throws Exception {
+	public void downloadAllPhotos() throws Exception {
 		for (AbstractSet set : this.sets) {
-			if (limitDownloadsToSets.size() > 0 && !limitDownloadsToSets.contains(set.getSetId()))
+			if (configuration.limitDownloadsToSets.size() > 0 && !configuration.limitDownloadsToSets.contains(set.getSetId()))
 				continue;
 
 			File setDir = set.getSetDirectory();

--- a/dev/src/java/org/gftp/FlickrDownload/Sets.java
+++ b/dev/src/java/org/gftp/FlickrDownload/Sets.java
@@ -67,6 +67,9 @@ public class Sets {
 	public Element createTopLevelXml() throws JDOMException, IOException {
 		Element allSets = new Element("sets");
     	for (AbstractSet set : this.sets) {
+			if (configuration.limitDownloadsToSets.size() > 0 && !configuration.limitDownloadsToSets.contains(set.getSetId()))
+				continue;
+
     		allSets.addContent(set.createToplevelXml());
     	}
     	return allSets;


### PR DESCRIPTION
These are some commits I haven't looked at in a while, but I have tested. The main point was to restrict processing to the sets that were requested. Part of that involved moving `limitDownloadsToSets` into the `configuration` rather than passing it around, if I recall and understand the diff correctly.